### PR TITLE
feat: add the ability to debug custom nodes easily

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -2,7 +2,7 @@
 #                              Main Configuration                              #
 # ---------------------------------------------------------------------------- #
 
-NODE_VERSIONS=20
+NODE_VERSION=20
 N8N_VERSION=1.81.4
 POSTGRES_VERSION=16
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,17 +2,15 @@
 #                              Pulling Base Image                              #
 # ---------------------------------------------------------------------------- #
 
-ARG N8N_VERSION
-FROM n8nio/n8n:${N8N_VERSION}
+ARG NODE_VERSION
+FROM n8nio/base:${NODE_VERSION}
 
 # ---------------------------------------------------------------------------- #
 #                       Setting Up The Build Environment                       #
 # ---------------------------------------------------------------------------- #
 
-USER root
-RUN apk add --no-cache --update sudo bash
+RUN apk add --no-cache --update openssh sudo shadow bash
 RUN echo node ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/node && chmod 0440 /etc/sudoers.d/node
 RUN mkdir /workspaces && chown node:node /workspaces
-ENV NODE_ENV=development 
 USER node
 RUN mkdir -p ~/.pnpm-store && pnpm config set store-dir ~/.pnpm-store --global

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,5 +15,7 @@
                 "mhutchie.git-graph"
             ]
         }
-    }
+    },
+    "postCreateCommand": "cd /workspace/n8n && corepack prepare --activate && pnpm install",
+    "postAttachCommand": "cd /workspace/n8n && pnpm build"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,7 @@
     "workspaceFolder": "/workspace",
     "dockerComposeFile": [
         "docker-compose.yaml",
-        "docker-compose.devcontainer.yaml",
-        "docker-compose.extends.yaml"
+        "docker-compose.devcontainer.yaml"
     ],
     "service": "n8n_web",
     "shutdownAction": "stopCompose",
@@ -17,5 +16,6 @@
         }
     },
     "postCreateCommand": "cd /workspace/n8n && corepack prepare --activate && pnpm install",
+    "postStartCommand": "sudo bash /workspace/.devcontainer/link_custom_nodes.sh",
     "postAttachCommand": "cd /workspace/n8n && pnpm build"
 }

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       context: ../
       dockerfile: ./.devcontainer/Dockerfile
       args:
-        - N8N_VERSION=${N8N_VERSION}
+        - NODE_VERSION=${NODE_VERSION}
     depends_on:
       - n8n_db
     ports:

--- a/.devcontainer/link_custom_nodes.sh
+++ b/.devcontainer/link_custom_nodes.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Change the owner of the .n8n directory to the node user
+chown node:node /home/node/.n8n
+
+# Create the /home/node/.n8n/custom directory if it doesn't exist
+mkdir -p /home/node/.n8n/custom
+
+# Go to the custom directory
+cd /home/node/.n8n/custom
+
+# Loop through each directory in /workspace/custom-nodes and create a link to the n8n instance
+for repo_path in /workspace/custom-nodes/*;
+do
+    if [ -d "$repo_path" ]; then
+        echo "Exploring $repo_path folder"
+        repo_name=$(jq -r '.name' "$repo_path/package.json")
+        echo "Checking $repo_name in package.json from $repo_path"
+        if ! grep -q "\"$repo_name\"" /home/node/.n8n/custom/package.json; then
+            echo "Linking $repo_name to n8n"
+            pnpm link "$repo_path"
+        else
+            echo "$repo_name is already linked in package.json"
+        fi
+    fi
+done

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 
 custom-nodes/
 
+n8n/
+
 node_modules/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,91 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch n8n with debug",
-            "program": "/usr/local/bin/n8n",
-            "cwd": "${workspaceFolder}",
-            "request": "launch",
             "type": "node",
+            "request": "launch",
+            "name": "Jest: current file",
+            "program": "${workspaceFolder}/n8n/node_modules/.bin/jest",
+            "args": [
+                "${fileBasenameNoExtension}"
+            ],
+            "console": "integratedTerminal",
+            "windows": {
+                "program": "${workspaceFolder}/n8n/node_modules/jest/bin/jest"
+            }
+        },
+        {
+            "name": "Attach to running n8n",
+            "processId": "${command:PickProcess}",
+            "request": "attach",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        {
+            "name": "Launch n8n with debug",
+            "program": "${workspaceFolder}/n8n/packages/cli/bin/n8n",
+            "cwd": "${workspaceFolder}/n8n/packages/cli/bin",
+            // "args": ["start", "--tunnel"],
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node",
+            "env": {
+                // "N8N_PORT": "5679",
+            },
             "outputCapture": "std",
             "killBehavior": "polite"
+        },
+        {
+            "name": "Launch n8n CLI dev with debug",
+            "runtimeExecutable": "pnpm",
+            "cwd": "${workspaceFolder}/n8n/packages/cli",
+            "runtimeArgs": [
+                "run",
+                "buildAndDev",
+                "--",
+                "--inspect-brk"
+            ],
+            "console": "integratedTerminal",
+            "restart": true,
+            "autoAttachChildProcesses": true,
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node",
+            "envFile": "${workspaceFolder}/n8n/.env",
+            "outputCapture": "std",
+            "killBehavior": "polite"
+        },
+        {
+            "name": "Debug CLI tests",
+            "cwd": "${workspaceFolder}/n8n/packages/cli",
+            "runtimeExecutable": "npm",
+            "args": [
+                "run",
+                "test"
+                // "--",
+                // "ActiveExecutions"
+            ],
+            "type": "node",
+            "request": "launch"
         }
     ]
+    /**
+		How this works:
+
+		This file gives VS Code the ability to start and debug n8n.
+		The editor is not debuggable from here.
+
+		The "Run and Debug" tab of your editor should display the "Launch n8n with debug" option.
+		This should start n8n and open a debug console. You can add breakpoints to
+		Parts of the code residing inside `cli`, `core`, `workflow` and `nodes-base` packages
+
+		You can also choose to "Attach to running n8n". This is useful if you
+		have n8n running in another terminal window and want to debug it.
+		Once you click to Debug, VS Code will prompt you to select a process to attach to.
+	*/
 }


### PR DESCRIPTION
# Improve Devcontainer Setup and Debugging for n8n  

## Summary  
This PR refactors the development environment by improving the devcontainer setup, enabling easier debugging, and ensuring better consistency with the official n8n repository.  

## Changes  

### Devcontainer Enhancements  
- Removed unnecessary `docker-compose` file from the configuration.  
- Added a `postStartCommand` to execute a script for linking custom nodes.  
- Introduced `link_custom_nodes.sh` to manage custom node linking in the n8n instance.  

### Debugging Improvements  
- Enhanced VS Code launch configurations by adding a setup from the official n8n repository for easier debugging.  
- Now using the `n8n` source code inside the `n8n/` folder instead of relying on the `n8n` image.  
- Updated the devcontainer setup to match the official n8n development environment:  
  - Uses the `n8nio/base` Docker image.  
  - Enables building n8n code within the container.  
  - Allows debugging internal nodes directly.  
  - Simplifies the process of adding and testing custom nodes.  

### Fixes  
- Corrected the `NODE_VERSIONS` variable name in `.env.example` to `NODE_VERSION` for consistency.  

## Why This Is Needed  
These changes improve the developer experience by aligning the development setup more closely with the official n8n environment, making debugging and custom node management significantly easier.  

## How to Test  
1. Rebuild the devcontainer.  
2. Verify that the `postStartCommand` correctly links custom nodes.  
3. Ensure that debugging configurations in VS Code work as expected.  