### PR TITLE
feat: Make hot reload work on custom nodes

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -15,3 +15,11 @@ DB_PORT=5432
 DB_USER=n8n
 DB_PASSWORD=n8n
 DB_NAME=n8n_db
+
+# ---------------------------------------------------------------------------- #
+#                             Development Features                             #
+# ---------------------------------------------------------------------------- #
+
+NODE_ENV=development
+N8N_DEV_RELOAD=true
+N8N_LOG_LEVEL=debug

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "mhutchie.git-graph"
+                "mhutchie.git-graph",
+                "eamodio.gitlens"
             ]
         }
     },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,91 +5,46 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "node",
-            "request": "launch",
-            "name": "Jest: current file",
-            "program": "${workspaceFolder}/n8n/node_modules/.bin/jest",
-            "args": [
-                "${fileBasenameNoExtension}"
-            ],
-            "console": "integratedTerminal",
-            "windows": {
-                "program": "${workspaceFolder}/n8n/node_modules/jest/bin/jest"
-            }
-        },
-        {
-            "name": "Attach to running n8n",
-            "processId": "${command:PickProcess}",
-            "request": "attach",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "type": "node"
-        },
-        {
             "name": "Launch n8n with debug",
-            "program": "${workspaceFolder}/n8n/packages/cli/bin/n8n",
-            "cwd": "${workspaceFolder}/n8n/packages/cli/bin",
-            // "args": ["start", "--tunnel"],
+            "type": "node",
             "request": "launch",
+            "cwd": "${workspaceFolder}/n8n/packages/cli/bin",
+            "program": "${workspaceFolder}/n8n/packages/cli/bin/n8n",
+            "runtimeArgs": [
+                "--watch"
+            ],
+            "preLaunchTask": "Run pnpm run dev in each node folder",
+            // "console": "integratedTerminal",
+            "restart": true,
+            "autoAttachChildProcesses": true,
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "type": "node",
-            "env": {
-                // "N8N_PORT": "5679",
-            },
             "outputCapture": "std",
-            "killBehavior": "polite"
+            "killBehavior": "polite",
         },
         {
             "name": "Launch n8n CLI dev with debug",
-            "runtimeExecutable": "pnpm",
+            "type": "node",
+            "request": "launch",
             "cwd": "${workspaceFolder}/n8n/packages/cli",
+            "runtimeExecutable": "pnpm",
             "runtimeArgs": [
                 "run",
                 "buildAndDev",
-                "--",
-                "--inspect-brk"
             ],
+            "args": [
+                "--watch"
+            ],
+            "preLaunchTask": "Run pnpm run dev in each node folder",
             "console": "integratedTerminal",
             "restart": true,
             "autoAttachChildProcesses": true,
-            "request": "launch",
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "type": "node",
-            "envFile": "${workspaceFolder}/n8n/.env",
             "outputCapture": "std",
             "killBehavior": "polite"
-        },
-        {
-            "name": "Debug CLI tests",
-            "cwd": "${workspaceFolder}/n8n/packages/cli",
-            "runtimeExecutable": "npm",
-            "args": [
-                "run",
-                "test"
-                // "--",
-                // "ActiveExecutions"
-            ],
-            "type": "node",
-            "request": "launch"
         }
     ]
-    /**
-		How this works:
-
-		This file gives VS Code the ability to start and debug n8n.
-		The editor is not debuggable from here.
-
-		The "Run and Debug" tab of your editor should display the "Launch n8n with debug" option.
-		This should start n8n and open a debug console. You can add breakpoints to
-		Parts of the code residing inside `cli`, `core`, `workflow` and `nodes-base` packages
-
-		You can also choose to "Attach to running n8n". This is useful if you
-		have n8n running in another terminal window and want to debug it.
-		Once you click to Debug, VS Code will prompt you to select a process to attach to.
-	*/
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run pnpm run dev in each node folder",
+            "type": "shell",
+            "command": "for d in /workspace/custom-nodes/*/ ; do (cd \"$d\" && pnpm run dev); done",
+            "isBackground": true,
+            "problemMatcher": [],
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -46,16 +46,15 @@ And this is exactly what this repository is all about.
 
 1. Clone this repository and navigate to the root folder.
 2. **[Optionnal (done during the dev container creation process)]** Clone the [n8n repository](https://github.com/n8n-io/n8n) at the workspace root and the [n8n-nodes-starter repository](https://github.com/n8n-io/n8n-nodes-starter) in the `custom-nodes` folder. You could also execute the `.devcontainer/init.sh` script to do it for you.
-4. Create a `.env` file in the `.devcontainers` folder. You can use `.env.example` as a template.
+3. Create a `.env` file in the `.devcontainers` folder. You can use `.env.example` as a template.
    - Used for docker-compose [variable interpolation](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#interpolation-syntax)
    - Used as [`.env` file for the n8n container](https://docs.docker.com/reference/compose-file/services/#env_file)
-5. Use `F1` or `Ctrl+Shift+P` and select `Dev Containers: Reopen in Container` in VSCode. The first start it long (5m on my end) because it builds up n8n from source, but subsequent starts are a matter of seconds.
-6. Go to your custom node folder and run `pnpm install` to install dependencies.
-7. Still inside your custom node folder, run `pnpm build` to build your custom node.
-6. Then press `F5` to start the n8n server in debug mode using `Launch n8n with debug` launch config. 
-7. Add breakpoint to your custom node Typescript or n8n source code and start debugging !
-
-If you want to see changes in your custom nodes, you can run `pnpm run dev` in your custom node folder to watch for changes and rebuild automatically. You'll still need to restart the n8n server to see the changes thought, this is tracked in issue [#5](https://github.com/mathisgauthey/n8n-nodes-builder/issues/5).
+4. Use `F1` or `Ctrl+Shift+P` and select `Dev Containers: Reopen in Container` in VSCode. The first start it long (5m on my end) because it builds up n8n from source, but subsequent starts are a matter of seconds.
+5. Go to your custom node folder and run `pnpm install` to install dependencies.
+6. Still inside your custom node folder, run `pnpm build` to build your custom node.
+7. **[Optinal (done as preLaunchTask inside `launch.json`)]** You can also run `pnpm dev` in a terminal to watch for changes and rebuild automatically.
+8. Then press `F5` to start the n8n server in debug mode using `Launch n8n with debug` launch config. It will run `pnpm dev` in the custom nodes folder and start the n8n server in debug mode. The server will automatically restart when you make changes to the n8n source code or your custom nodes thanks to the `--watch` directive.
+9. Add breakpoint to your custom node Typescript or n8n source code and start debugging !
 
 ## Inspirations
 


### PR DESCRIPTION
Uses the `--watch` directive to reload n8n server when changes are detected either in n8n source code or any of the custom nodes directory.

Also add a pre launch task that will run `pnpm run dev` inside each custom node folder so that the changes are reflected and seen by the watch directive.

Fixes #5