### PR TITLE
feat: update launch configurations for n8n to include start command and source maps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,50 +1,68 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Launch n8n with debug",
-            "type": "node",
-            "request": "launch",
-            "cwd": "${workspaceFolder}/n8n/packages/cli/bin",
-            "program": "${workspaceFolder}/n8n/packages/cli/bin/n8n",
-            "runtimeArgs": [
-                "--watch"
-            ],
-            "preLaunchTask": "Run pnpm i and pnpm run dev in each node folder",
-            "console": "integratedTerminal",
-            "restart": true,
-            "autoAttachChildProcesses": true,
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "outputCapture": "std",
-            "killBehavior": "polite"
-        },
-        {
-            "name": "Launch n8n CLI dev with debug",
-            "type": "node",
-            "request": "launch",
-            "cwd": "${workspaceFolder}/n8n/packages/cli",
-            "runtimeExecutable": "pnpm",
-            "runtimeArgs": [
-                "run",
-                "buildAndDev"
-            ],
-            "args": [
-                "--watch"
-            ],
-            "preLaunchTask": "Run pnpm i and pnpm run dev in each node folder",
-            "console": "integratedTerminal",
-            "restart": true,
-            "autoAttachChildProcesses": true,
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "outputCapture": "std",
-            "killBehavior": "polite"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Start n8n",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/n8n",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": [
+        "run",
+        "start"
+      ],
+      "preLaunchTask": "Run pnpm i and pnpm run dev in each node folder",
+      "console": "integratedTerminal",
+      "restart": true,
+      "autoAttachChildProcesses": true,
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "outputCapture": "std",
+      "killBehavior": "polite",
+      "sourceMaps": true
+    },
+    {
+      "name": "Launch n8n with debug",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/n8n/packages/cli/bin",
+      "program": "${workspaceFolder}/n8n/packages/cli/bin/n8n",
+      "runtimeArgs": [
+        "--watch"
+      ],
+      "preLaunchTask": "Run pnpm i and pnpm run dev in each node folder",
+      "console": "integratedTerminal",
+      "restart": true,
+      "autoAttachChildProcesses": true,
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "outputCapture": "std",
+      "killBehavior": "polite"
+    },
+    {
+      "name": "Launch n8n CLI dev with debug",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/n8n/packages/cli",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": [
+        "run",
+        "buildAndDev"
+      ],
+      "args": [
+        "--watch"
+      ],
+      "preLaunchTask": "Run pnpm i and pnpm run dev in each node folder",
+      "console": "integratedTerminal",
+      "restart": true,
+      "autoAttachChildProcesses": true,
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "outputCapture": "std",
+      "killBehavior": "polite"
+    }
+  ]
 }


### PR DESCRIPTION
Basically allows for quicker restarts which are required in n8n custom node development.

This is based on a [comment from jan](https://community.n8n.io/t/development-mode-doesnt-work/7191/7), a n8n founder.

And [another](https://community.n8n.io/t/custom-node-hot-reload-gui-search-install/5529/3) from lublak that says that restarting the server is required often in custom node development.